### PR TITLE
style: use `tslint-config-prettier` so that prettier doesn't break lint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7646,6 +7646,12 @@
         "tslint-react": "^3.6.0"
       }
     },
+    "tslint-config-prettier": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/tslint-config-prettier/-/tslint-config-prettier-1.18.0.tgz",
+      "integrity": "sha512-xPw9PgNPLG3iKRxmK7DWr+Ea/SzrvfHtjFt5LBl61gk2UBG/DB9kCXRjv+xyIU1rUtnayLeMUVJBcMX8Z17nDg==",
+      "dev": true
+    },
     "tslint-consistent-codestyle": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/tslint-consistent-codestyle/-/tslint-consistent-codestyle-1.15.0.tgz",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "prettier": "^1.16.4",
     "tslint": "^5.13.1",
     "tslint-config-euclid": "0.0.8",
+    "tslint-config-prettier": "^1.18.0",
     "typescript": "^3.3.3333"
   },
   "homepage": "https://github.com/dbpiper/Euclid#readme",

--- a/src/client/package-lock.json
+++ b/src/client/package-lock.json
@@ -21326,6 +21326,12 @@
         "tsutils": "^2.27.2"
       }
     },
+    "tslint-config-prettier": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/tslint-config-prettier/-/tslint-config-prettier-1.18.0.tgz",
+      "integrity": "sha512-xPw9PgNPLG3iKRxmK7DWr+Ea/SzrvfHtjFt5LBl61gk2UBG/DB9kCXRjv+xyIU1rUtnayLeMUVJBcMX8Z17nDg==",
+      "dev": true
+    },
     "tslint-plugin-cypress": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/tslint-plugin-cypress/-/tslint-plugin-cypress-1.0.4.tgz",

--- a/src/client/package.json
+++ b/src/client/package.json
@@ -129,6 +129,7 @@
     "redux-test-utils": "^0.3.0",
     "storybook-addon-jsx": "^6.0.0",
     "tslint": "^5.13.1",
+    "tslint-config-prettier": "^1.18.0",
     "tslint-plugin-cypress": "^1.0.4",
     "typescript": "^3.3.3333"
   },

--- a/src/client/tslint.json
+++ b/src/client/tslint.json
@@ -1,7 +1,8 @@
 {
   "defaultSeverity": "error",
   "extends": [
-    "tslint-config-euclid"
+    "tslint-config-euclid",
+    "tslint-config-prettier"
   ],
   "jsRules": {},
   "linterOptions": {

--- a/src/server/package-lock.json
+++ b/src/server/package-lock.json
@@ -9782,6 +9782,12 @@
         "tsutils": "^2.27.2"
       }
     },
+    "tslint-config-prettier": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/tslint-config-prettier/-/tslint-config-prettier-1.18.0.tgz",
+      "integrity": "sha512-xPw9PgNPLG3iKRxmK7DWr+Ea/SzrvfHtjFt5LBl61gk2UBG/DB9kCXRjv+xyIU1rUtnayLeMUVJBcMX8Z17nDg==",
+      "dev": true
+    },
     "tsutils": {
       "version": "2.29.0",
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",

--- a/src/server/package.json
+++ b/src/server/package.json
@@ -47,6 +47,7 @@
     "jsdoc": "^3.5.5",
     "ts-jest": "^23.10.5",
     "tslint": "^5.13.1",
+    "tslint-config-prettier": "^1.18.0",
     "typescript": "^3.3.3333"
   },
   "license": "MIT",

--- a/src/server/tslint.json
+++ b/src/server/tslint.json
@@ -1,7 +1,8 @@
 {
   "defaultSeverity": "error",
   "extends": [
-    "tslint-config-euclid"
+    "tslint-config-euclid",
+    "tslint-config-prettier"
   ],
   "jsRules": {},
   "rules": {

--- a/tslint.json
+++ b/tslint.json
@@ -1,7 +1,8 @@
 {
     "defaultSeverity": "error",
     "extends": [
-        "tslint:recommended"
+        "tslint:recommended",
+        "tslint-config-prettier"
     ],
     "jsRules": {},
     "rules": {},


### PR DESCRIPTION
Prettier is "pretty" good, however it has a very simplistic approach
to code-formatting and is not very configurable. This means that
it breaks tons of linting rules and style-guides. This is unfortunate
as it means that developers have to choose between the style-guide
and prettier.

However, since prettier does do a good job of code-formatting I think
that it is acceptable to use its formatting despite it not following
airbnb (the usual style guide for Euclid).